### PR TITLE
Improvements + fix failing test

### DIFF
--- a/pep508/pep508.py
+++ b/pep508/pep508.py
@@ -43,15 +43,11 @@ def parse_quoted_marker(tokens):
     #TODO: consume everything until first ";"
     tokens.try_read('SEMICOLON')
     logging.debug('read ";", attempting to read marker')
-    while tokens.try_read('WSP'):
-        pass
     return parse_marker_or(tokens)
 
 def parse_marker_or(tokens):
     logging.debug('parse_marker_or left side')
     marker_and_left = parse_marker_and(tokens)
-    while tokens.try_read('WSP'):
-        pass
     if tokens.try_read('OR'):
         marker_and_right = parse_marker_and(tokens)
         return [marker_and_left, 'or', marker_and_right]
@@ -63,8 +59,6 @@ def parse_marker_and(tokens):
     logging.debug(f'parse_marker_and left side')
     marker_expr_left = parse_marker_expr(tokens)
     logging.debug(f'parse_marker_and left side {marker_expr_left}')
-    while tokens.try_read('WSP'):
-        pass
     # if next token is OR, we parsed left part of marker_or and we have to
     # continue with parsing in parse_marker_or()
     if tokens.match('OR'):
@@ -80,8 +74,6 @@ def parse_marker_and(tokens):
         return [marker_expr_left]
 
 def parse_marker_expr(tokens):
-    while tokens.try_read('WSP'):
-        pass
     if tokens.try_read('LPAREN'):
         marker = parse_marker_or(tokens)
         logging.debug(f'marker {marker}')
@@ -106,8 +98,6 @@ def parse_marker_expr(tokens):
 # ops['<']('12', '34')
 
 def parse_marker_var(tokens):
-    while tokens.try_read('WSP'):
-        pass
     if tokens.match('ENV_VAR'):
         logging.debug('parse_marker_var detected ENV_VAR')
         return parse_env_var(tokens)
@@ -136,8 +126,6 @@ def parse_env_var(tokens):
         return Variable(env_var)
 
 def parse_python_str(tokens):
-    while tokens.try_read('WSP'):
-        pass
     if tokens.match('PYTHON_STR'):
         python_str = tokens.read().text.strip("\'\"")
         return Value(str(python_str))
@@ -145,19 +133,11 @@ def parse_python_str(tokens):
         tokens.raise_syntax_error('python_str expected, should begin with single or double quote')
 
 def parse_marker_op(tokens):
-    while tokens.try_read('WSP'):
-        pass
     if tokens.try_read('IN'):
         logging.debug('parse_marker_op detected "in"')
         return Op('in')
     elif tokens.try_read('NOT'):
-        tokens.expect('WSP')
-        while tokens.try_read('WSP'):
-            pass
-        tokens.expect('IN')
         tokens.read('IN')
-        while tokens.try_read('WSP'):
-            pass
         logging.debug('parse_marker_op detected "not in"')
         return Op('not in')
     elif tokens.match('OP'):

--- a/pep508/pep508.py
+++ b/pep508/pep508.py
@@ -8,7 +8,6 @@ from packaging.version import parse
 from packaging.markers import Variable, Value, Op
 
 from .tokenizer import Tokenizer
-from .my_ast import SimpleAssignment, String, BinOp
 
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
@@ -170,5 +169,4 @@ def parse_marker_op(tokens):
         tokens.raise_syntax_error('Failed to parse marker_op. Should be one of "<=, <, !=, ==, >=, >, ~=, ===, not, not in"')
 
 #node = parse_quoted_marker(tokens)
-#my_ast.dump(node)
 #print(node.eval({}))

--- a/pep508/pep508.py
+++ b/pep508/pep508.py
@@ -47,14 +47,14 @@ def parse_quoted_marker(tokens):
 
 def parse_marker_expr(tokens):
     """
-    MARKER_EXPR: MARKER_ATOM (BOOLOP + MARKER_EXPR)+
+    MARKER_EXPR: MARKER_ATOM (BOOLOP + MARKER_ATOM)+
     """
     logging.debug(f'parse_marker_and left side')
     expression = [parse_marker_atom(tokens)]
     logging.debug(f'parse_marker_and left side {expression}')
     while tok := tokens.try_read('BOOLOP'):
         logging.debug('parse_marker_and detected "and"')
-        expr_right = parse_marker_expr(tokens)
+        expr_right = parse_marker_atom(tokens)
         logging.debug(f'parse_marker_and right side {expr_right}')
         expression.extend((tok.text, expr_right))
     logging.debug(f'parse_marker_and finished, returning {expression}')

--- a/pep508/tokenizer.py
+++ b/pep508/tokenizer.py
@@ -24,7 +24,7 @@ class Token:
 
 
 DEFAULT_RULES = {
-    'WSP': r' +|\t+',  # spaces and comments
+    None: r'[ \t]+',  # whitespace: not returned as tokens
     'LPAREN': r'\(',
     'RPAREN': r'\)',
     'SEMICOLON': r';',

--- a/pep508/tokenizer.py
+++ b/pep508/tokenizer.py
@@ -28,15 +28,14 @@ DEFAULT_RULES = {
     'LPAREN': r'\(',
     'RPAREN': r'\)',
     'SEMICOLON': r';',
-    'PYTHON_STR': r'(\'([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\"])*\')|(\"([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\'])*\")',
+    'QUOTED_STRING': r'(\'([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\"])*\')|(\"([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\'])*\")',
     'OP': r'===|==|~=|!=|<=|>=|<|>',
     'SQUOTE': r'\'',
     'DQUOTE': r'\"',
-    'OR': r'or',
-    'AND': r'and',
+    'BOOLOP': r'or|and',
     'IN': r'in',
     'NOT': r'not',
-    'ENV_VAR': r'python_version|python_full_version|os_name|sys_platform|platform_release|platform_system|platform_version|platform_machine|platform_python_implementation|implementation_name|implementation_version|extra|os\.name|sys\.platform|platform\.version|platform\.machine|platform\.python_implementation|python_implementation',
+    'VARIABLE': r'python_version|python_full_version|os_name|sys_platform|platform_release|platform_system|platform_version|platform_machine|platform_python_implementation|implementation_name|implementation_version|extra|os\.name|sys\.platform|platform\.version|platform\.machine|platform\.python_implementation|python_implementation',
 
 #    None: r' +|#[^\n]*',  # spaces and comments
 }


### PR DESCRIPTION
Hi!
This PR is bigger than it needs to be – I best learn about a codebase by tweaking it, so I left the more useful tweaks in as commits.
Hopefully they will make sense.

The main change here is the *while loop* to implement the rule that original packaging (pyparsing) spells as:
```
MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_EXPR)
```

so, `"a"!="b" and "c"!="d" and "d"!="e" or "f"!="g"` is all parsed as a single expression. (The `_evaluate_markers` function then deals with operator precedence, which seems more complex than it needs to be, but that code is already written...)

The rule is then adjusted to be more like:
```
MARKER_EXPR << MARKER_ATOM + ZeroOrMore(BOOLOP + MARKER_ATOM)
```
so that the above example is not parsed as `("a"!="b" and ("c"!="d" and ("d"!="e" or ("f"!="g"))))` but as `("a"!="b") and ("c"!="d") and ("d"!="e") or ("f"!="g")`.
