### PR TITLE
Simplify tokenizer & token definitions

### DIFF
--- a/pep508/__init__.py
+++ b/pep508/__init__.py
@@ -5,6 +5,6 @@
 #__all__ = ['parse_quoted_marker', 'Tokenizer']
 
 from pep508.pep508 import parse_quoted_marker
-from pep508.tokenizer import Tokenizer
+from pep508.tokenizer import Tokenizer, PackagingSyntaxError
 
-__all__ = ['parse_quoted_marker', 'Tokenizer', 'String', 'BinOp', 'SimpleAssignment']
+__all__ = ['parse_quoted_marker', 'Tokenizer', 'String', 'BinOp', 'SimpleAssignment', 'PackagingSyntaxError']

--- a/pep508/tokenizer.py
+++ b/pep508/tokenizer.py
@@ -31,14 +31,34 @@ DEFAULT_RULES = {
     'LPAREN': r'\(',
     'RPAREN': r'\)',
     'SEMICOLON': r';',
-    'QUOTED_STRING': r'(\'([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\"])*\')|(\"([\ a-zA-Z0-9\(\)\.{}\-_\*#:;,\/\?\[\]\!\~`@\$%\^\&\=\+\|<>\'])*\")',
+    'QUOTED_STRING': re.compile(
+        r'''
+            ('[^']*')
+            |
+            ("[^"]*")
+        ''',
+        re.VERBOSE
+    ),
     'OP': r'===|==|~=|!=|<=|>=|<|>',
     'SQUOTE': r'\'',
     'DQUOTE': r'\"',
     'BOOLOP': r'or|and',
     'IN': r'in',
     'NOT': r'not',
-    'VARIABLE': r'python_version|python_full_version|os_name|sys_platform|platform_release|platform_system|platform_version|platform_machine|platform_python_implementation|implementation_name|implementation_version|extra|os\.name|sys\.platform|platform\.version|platform\.machine|platform\.python_implementation|python_implementation',
+    'VARIABLE': re.compile(
+        r'''
+            python_version
+            |python_full_version
+            |os[._]name
+            |sys[._]platform
+            |platform_(release|system)
+            |platform[._](version|machine|python_implementation)
+            |python_implementation
+            |implementation_(name|version)
+            |extra
+        ''',
+        re.VERBOSE
+    ),
 }
 
 


### PR DESCRIPTION
- The PEP 508 tokenizer only needs to work with a single line, so instead of tracking line & column numbers it can use a single number as position. This means it can be simplified quite a lot..
- Some of the token rules are much more readable as [VERBOSE regexes](https://docs.python.org/3/library/re.html#re.VERBOSE).
- `SyntaxError` is a bit tricky to raise completely correctly, because Python assumes it's raised for imported Python code. It's better to use a custom exception. (I named it `PackagingSyntaxError`  because I assume this project will become part of `packaging`.)